### PR TITLE
Restructured `Schema` and `Column` to use a standard `name`

### DIFF
--- a/src/classes/autoinstall.ts
+++ b/src/classes/autoinstall.ts
@@ -90,7 +90,7 @@ export class AutoInstall {
         // Create table `schema`
         await this.createTable('system.schema', (table) => {
             table.string('schema_name').notNullable();
-            table.string('schema_type').notNullable().defaultTo('database');
+            table.string('type').notNullable().defaultTo('database');
             table.string('description');
 
             table.boolean('external').defaultTo(false);
@@ -127,10 +127,10 @@ export class AutoInstall {
 
         // Add data for `schema`
         await this.insertAll('system.schema', [
-            { ns: 'system', schema_name: 'system.domain', schema_type: 'database' },
-            { ns: 'system', schema_name: 'system.schema', schema_type: 'database', metadata: true },
-            { ns: 'system', schema_name: 'system.column', schema_type: 'database', metadata: true },
-            { ns: 'system', schema_name: 'system.user', schema_type: 'database', metadata: false },
+            { ns: 'system', schema_name: 'system.domain', type: 'database' },
+            { ns: 'system', schema_name: 'system.schema', type: 'database', metadata: true },
+            { ns: 'system', schema_name: 'system.column', type: 'database', metadata: true },
+            { ns: 'system', schema_name: 'system.user', type: 'database', metadata: false },
         ]);
 
         // Add data for `column`
@@ -140,7 +140,7 @@ export class AutoInstall {
 
             // Columns for 'schema'
             { ns: 'system', schema_name: 'system.schema', name: 'schema_name', required: true },
-            { ns: 'system', schema_name: 'system.schema', name: 'schema_type' },
+            { ns: 'system', schema_name: 'system.schema', name: 'type' },
             { ns: 'system', schema_name: 'system.schema', name: 'description' },
             { ns: 'system', schema_name: 'system.schema', name: 'external', type: 'boolean' },
             { ns: 'system', schema_name: 'system.schema', name: 'metadata', type: 'boolean' },

--- a/src/classes/autoinstall.ts
+++ b/src/classes/autoinstall.ts
@@ -99,7 +99,6 @@ export class AutoInstall {
 
         // Create table `column`
         await this.createTable('system.column', table => {
-            table.string('schema_name').notNullable();
             table.string('name').notNullable();
             table.string('type').notNullable().defaultTo('text');
             table.string('description');
@@ -130,40 +129,39 @@ export class AutoInstall {
             { ns: 'system', name: 'system.domain', type: 'database' },
             { ns: 'system', name: 'system.schema', type: 'database', metadata: true },
             { ns: 'system', name: 'system.column', type: 'database', metadata: true },
-            { ns: 'system', name: 'system.user', type: 'database', metadata: false },
+            { ns: 'system', name: 'system.user', type: 'database' },
         ]);
 
         // Add data for `column`
         await this.insertAll('system.column', [
             // Columns for 'system'
-            { ns: 'system', schema_name: 'system.domain', name: 'description' },
+            { ns: 'system', name: 'system.domain:description' },
 
             // Columns for 'schema'
-            { ns: 'system', schema_name: 'system.schema', name: 'name', required: true },
-            { ns: 'system', schema_name: 'system.schema', name: 'type' },
-            { ns: 'system', schema_name: 'system.schema', name: 'description' },
-            { ns: 'system', schema_name: 'system.schema', name: 'external', type: 'boolean' },
-            { ns: 'system', schema_name: 'system.schema', name: 'metadata', type: 'boolean' },
+            { ns: 'system', name: 'system.schema:name', required: true, immutable: true, indexed: true  },
+            { ns: 'system', name: 'system.schema:type' },
+            { ns: 'system', name: 'system.schema:description' },
+            { ns: 'system', name: 'system.schema:external', type: 'boolean' },
+            { ns: 'system', name: 'system.schema:metadata', type: 'boolean' },
 
             // Columns for 'column'
-            { ns: 'system', schema_name: 'system.column', name: 'schema_name', required: true, immutable: true, indexed: true },
-            { ns: 'system', schema_name: 'system.column', name: 'name', required: true, immutable: true, indexed: true },
-            { ns: 'system', schema_name: 'system.column', name: 'type', required: true, immutable: true, indexed: true },
-            { ns: 'system', schema_name: 'system.column', name: 'description' },
+            { ns: 'system', name: 'system.column:name', required: true, immutable: true, indexed: true },
+            { ns: 'system', name: 'system.column:type', required: true },
+            { ns: 'system', name: 'system.column:description' },
 
-            { ns: 'system', schema_name: 'system.column', name: 'audited', type: 'boolean' },
-            { ns: 'system', schema_name: 'system.column', name: 'immutable', type: 'boolean' },
-            { ns: 'system', schema_name: 'system.column', name: 'indexed', type: 'boolean' },
-            { ns: 'system', schema_name: 'system.column', name: 'internal', type: 'boolean' },
-            { ns: 'system', schema_name: 'system.column', name: 'required', type: 'boolean' },
-            { ns: 'system', schema_name: 'system.column', name: 'unique', type: 'boolean' },
+            { ns: 'system', name: 'system.column:audited', type: 'boolean' },
+            { ns: 'system', name: 'system.column:immutable', type: 'boolean' },
+            { ns: 'system', name: 'system.column:indexed', type: 'boolean' },
+            { ns: 'system', name: 'system.column:internal', type: 'boolean' },
+            { ns: 'system', name: 'system.column:required', type: 'boolean' },
+            { ns: 'system', name: 'system.column:unique', type: 'boolean' },
 
-            { ns: 'system', schema_name: 'system.column', name: 'minimum', type: 'integer' },
-            { ns: 'system', schema_name: 'system.column', name: 'maximum', type: 'integer' },
-            { ns: 'system', schema_name: 'system.column', name: 'precision', type: 'integer' },
+            { ns: 'system', name: 'system.column:minimum', type: 'integer' },
+            { ns: 'system', name: 'system.column:maximum', type: 'integer' },
+            { ns: 'system', name: 'system.column:precision', type: 'integer' },
 
             // Columns for 'user'
-            { ns: 'system', schema_name: 'system.user', name: 'name', type: 'text', required: true },
+            { ns: 'system', name: 'system.user:name', type: 'text', required: true },
         ]);
 
         // Add data for `client`

--- a/src/classes/autoinstall.ts
+++ b/src/classes/autoinstall.ts
@@ -100,7 +100,7 @@ export class AutoInstall {
         // Create table `column`
         await this.createTable('system.column', table => {
             table.string('schema_name').notNullable();
-            table.string('column_name').notNullable();
+            table.string('name').notNullable();
             table.string('column_type').notNullable().defaultTo('text');
             table.string('description');
 
@@ -136,34 +136,34 @@ export class AutoInstall {
         // Add data for `column`
         await this.insertAll('system.column', [
             // Columns for 'system'
-            { ns: 'system', schema_name: 'system.domain', column_name: 'description' },
+            { ns: 'system', schema_name: 'system.domain', name: 'description' },
 
             // Columns for 'schema'
-            { ns: 'system', schema_name: 'system.schema', column_name: 'schema_name', required: true },
-            { ns: 'system', schema_name: 'system.schema', column_name: 'schema_type' },
-            { ns: 'system', schema_name: 'system.schema', column_name: 'description' },
-            { ns: 'system', schema_name: 'system.schema', column_name: 'external', column_type: 'boolean' },
-            { ns: 'system', schema_name: 'system.schema', column_name: 'metadata', column_type: 'boolean' },
+            { ns: 'system', schema_name: 'system.schema', name: 'schema_name', required: true },
+            { ns: 'system', schema_name: 'system.schema', name: 'schema_type' },
+            { ns: 'system', schema_name: 'system.schema', name: 'description' },
+            { ns: 'system', schema_name: 'system.schema', name: 'external', column_type: 'boolean' },
+            { ns: 'system', schema_name: 'system.schema', name: 'metadata', column_type: 'boolean' },
 
             // Columns for 'column'
-            { ns: 'system', schema_name: 'system.column', column_name: 'schema_name', required: true, immutable: true, indexed: true },
-            { ns: 'system', schema_name: 'system.column', column_name: 'column_name', required: true, immutable: true, indexed: true },
-            { ns: 'system', schema_name: 'system.column', column_name: 'column_type', required: true, immutable: true, indexed: true },
-            { ns: 'system', schema_name: 'system.column', column_name: 'description' },
+            { ns: 'system', schema_name: 'system.column', name: 'schema_name', required: true, immutable: true, indexed: true },
+            { ns: 'system', schema_name: 'system.column', name: 'name', required: true, immutable: true, indexed: true },
+            { ns: 'system', schema_name: 'system.column', name: 'column_type', required: true, immutable: true, indexed: true },
+            { ns: 'system', schema_name: 'system.column', name: 'description' },
 
-            { ns: 'system', schema_name: 'system.column', column_name: 'audited', column_type: 'boolean' },
-            { ns: 'system', schema_name: 'system.column', column_name: 'immutable', column_type: 'boolean' },
-            { ns: 'system', schema_name: 'system.column', column_name: 'indexed', column_type: 'boolean' },
-            { ns: 'system', schema_name: 'system.column', column_name: 'internal', column_type: 'boolean' },
-            { ns: 'system', schema_name: 'system.column', column_name: 'required', column_type: 'boolean' },
-            { ns: 'system', schema_name: 'system.column', column_name: 'unique', column_type: 'boolean' },
+            { ns: 'system', schema_name: 'system.column', name: 'audited', column_type: 'boolean' },
+            { ns: 'system', schema_name: 'system.column', name: 'immutable', column_type: 'boolean' },
+            { ns: 'system', schema_name: 'system.column', name: 'indexed', column_type: 'boolean' },
+            { ns: 'system', schema_name: 'system.column', name: 'internal', column_type: 'boolean' },
+            { ns: 'system', schema_name: 'system.column', name: 'required', column_type: 'boolean' },
+            { ns: 'system', schema_name: 'system.column', name: 'unique', column_type: 'boolean' },
 
-            { ns: 'system', schema_name: 'system.column', column_name: 'minimum', column_type: 'integer' },
-            { ns: 'system', schema_name: 'system.column', column_name: 'maximum', column_type: 'integer' },
-            { ns: 'system', schema_name: 'system.column', column_name: 'precision', column_type: 'integer' },
+            { ns: 'system', schema_name: 'system.column', name: 'minimum', column_type: 'integer' },
+            { ns: 'system', schema_name: 'system.column', name: 'maximum', column_type: 'integer' },
+            { ns: 'system', schema_name: 'system.column', name: 'precision', column_type: 'integer' },
 
             // Columns for 'user'
-            { ns: 'system', schema_name: 'system.user', column_name: 'name', column_type: 'text', required: true },
+            { ns: 'system', schema_name: 'system.user', name: 'name', column_type: 'text', required: true },
         ]);
 
         // Add data for `client`

--- a/src/classes/autoinstall.ts
+++ b/src/classes/autoinstall.ts
@@ -89,7 +89,7 @@ export class AutoInstall {
 
         // Create table `schema`
         await this.createTable('system.schema', (table) => {
-            table.string('schema_name').notNullable();
+            table.string('name').notNullable();
             table.string('type').notNullable().defaultTo('database');
             table.string('description');
 
@@ -127,10 +127,10 @@ export class AutoInstall {
 
         // Add data for `schema`
         await this.insertAll('system.schema', [
-            { ns: 'system', schema_name: 'system.domain', type: 'database' },
-            { ns: 'system', schema_name: 'system.schema', type: 'database', metadata: true },
-            { ns: 'system', schema_name: 'system.column', type: 'database', metadata: true },
-            { ns: 'system', schema_name: 'system.user', type: 'database', metadata: false },
+            { ns: 'system', name: 'system.domain', type: 'database' },
+            { ns: 'system', name: 'system.schema', type: 'database', metadata: true },
+            { ns: 'system', name: 'system.column', type: 'database', metadata: true },
+            { ns: 'system', name: 'system.user', type: 'database', metadata: false },
         ]);
 
         // Add data for `column`
@@ -139,7 +139,7 @@ export class AutoInstall {
             { ns: 'system', schema_name: 'system.domain', name: 'description' },
 
             // Columns for 'schema'
-            { ns: 'system', schema_name: 'system.schema', name: 'schema_name', required: true },
+            { ns: 'system', schema_name: 'system.schema', name: 'name', required: true },
             { ns: 'system', schema_name: 'system.schema', name: 'type' },
             { ns: 'system', schema_name: 'system.schema', name: 'description' },
             { ns: 'system', schema_name: 'system.schema', name: 'external', type: 'boolean' },

--- a/src/classes/autoinstall.ts
+++ b/src/classes/autoinstall.ts
@@ -101,7 +101,7 @@ export class AutoInstall {
         await this.createTable('system.column', table => {
             table.string('schema_name').notNullable();
             table.string('name').notNullable();
-            table.string('column_type').notNullable().defaultTo('text');
+            table.string('type').notNullable().defaultTo('text');
             table.string('description');
 
             table.boolean('audited').defaultTo(false);
@@ -142,28 +142,28 @@ export class AutoInstall {
             { ns: 'system', schema_name: 'system.schema', name: 'schema_name', required: true },
             { ns: 'system', schema_name: 'system.schema', name: 'schema_type' },
             { ns: 'system', schema_name: 'system.schema', name: 'description' },
-            { ns: 'system', schema_name: 'system.schema', name: 'external', column_type: 'boolean' },
-            { ns: 'system', schema_name: 'system.schema', name: 'metadata', column_type: 'boolean' },
+            { ns: 'system', schema_name: 'system.schema', name: 'external', type: 'boolean' },
+            { ns: 'system', schema_name: 'system.schema', name: 'metadata', type: 'boolean' },
 
             // Columns for 'column'
             { ns: 'system', schema_name: 'system.column', name: 'schema_name', required: true, immutable: true, indexed: true },
             { ns: 'system', schema_name: 'system.column', name: 'name', required: true, immutable: true, indexed: true },
-            { ns: 'system', schema_name: 'system.column', name: 'column_type', required: true, immutable: true, indexed: true },
+            { ns: 'system', schema_name: 'system.column', name: 'type', required: true, immutable: true, indexed: true },
             { ns: 'system', schema_name: 'system.column', name: 'description' },
 
-            { ns: 'system', schema_name: 'system.column', name: 'audited', column_type: 'boolean' },
-            { ns: 'system', schema_name: 'system.column', name: 'immutable', column_type: 'boolean' },
-            { ns: 'system', schema_name: 'system.column', name: 'indexed', column_type: 'boolean' },
-            { ns: 'system', schema_name: 'system.column', name: 'internal', column_type: 'boolean' },
-            { ns: 'system', schema_name: 'system.column', name: 'required', column_type: 'boolean' },
-            { ns: 'system', schema_name: 'system.column', name: 'unique', column_type: 'boolean' },
+            { ns: 'system', schema_name: 'system.column', name: 'audited', type: 'boolean' },
+            { ns: 'system', schema_name: 'system.column', name: 'immutable', type: 'boolean' },
+            { ns: 'system', schema_name: 'system.column', name: 'indexed', type: 'boolean' },
+            { ns: 'system', schema_name: 'system.column', name: 'internal', type: 'boolean' },
+            { ns: 'system', schema_name: 'system.column', name: 'required', type: 'boolean' },
+            { ns: 'system', schema_name: 'system.column', name: 'unique', type: 'boolean' },
 
-            { ns: 'system', schema_name: 'system.column', name: 'minimum', column_type: 'integer' },
-            { ns: 'system', schema_name: 'system.column', name: 'maximum', column_type: 'integer' },
-            { ns: 'system', schema_name: 'system.column', name: 'precision', column_type: 'integer' },
+            { ns: 'system', schema_name: 'system.column', name: 'minimum', type: 'integer' },
+            { ns: 'system', schema_name: 'system.column', name: 'maximum', type: 'integer' },
+            { ns: 'system', schema_name: 'system.column', name: 'precision', type: 'integer' },
 
             // Columns for 'user'
-            { ns: 'system', schema_name: 'system.user', name: 'name', column_type: 'text', required: true },
+            { ns: 'system', schema_name: 'system.user', name: 'name', type: 'text', required: true },
         ]);
 
         // Add data for `client`

--- a/src/classes/column.ts
+++ b/src/classes/column.ts
@@ -6,7 +6,7 @@ export class Column {
 
     public readonly schema_name: string;
     public readonly name: string;
-    public readonly column_type: string;
+    public readonly type: string;
     
     public readonly audited: boolean;
     public readonly immutable: boolean;
@@ -24,7 +24,7 @@ export class Column {
 
         this.schema_name = flat.schema_name;
         this.name = flat.name;
-        this.column_type = flat.column_type;
+        this.type = flat.type;
 
         this.audited = flat.audited;
         this.immutable = flat.immutable;

--- a/src/classes/column.ts
+++ b/src/classes/column.ts
@@ -4,7 +4,6 @@ export class Column {
     public readonly id: string;
     public readonly ns: string;
 
-    public readonly schema_name: string;
     public readonly name: string;
     public readonly type: string;
     
@@ -22,7 +21,6 @@ export class Column {
         this.id = flat.id;
         this.ns = flat.ns;
 
-        this.schema_name = flat.schema_name;
         this.name = flat.name;
         this.type = flat.type;
 
@@ -37,9 +35,30 @@ export class Column {
         this.maximum = flat.maximum;
     }
 
-    // Bonus
-
-    get column_path(): string {
-        return this.schema_name + ':' + this.name;
+    /**
+     * Returns only the `schema_name` portion of the full name property. For example, if the column's name
+     * property is set to `system.domain:name`, then `schema_name` returns `system.domain`.
+     */
+    get schema_name() {
+        return _.head(this.name.split(':'));
     }
+
+    /**
+     * Returns only the `column_name` portion of the full name property. For example, if the column's name
+     * property is set to `system.domain:name`, then `column_name` returns `name`.
+     */
+    get column_name() {
+        return _.last(this.name.split(':'));
+    }
+
+    /**
+     * Returns the two path parts of the column name. For example, if the column is `system.domain:name`,
+     * then the `path()` function will return an array `[undefined, 'name']`. If the column is in namespace
+     * itself, such as `package.myobj:customer.field`, then `path()` will return `['customer', 'field']`.
+     * @returns An array with two parts
+     */
+    path() {
+        return this.name.includes('.') ? this.name.split('.') : [undefined, this.name];
+    }
+
 }

--- a/src/classes/column.ts
+++ b/src/classes/column.ts
@@ -5,7 +5,7 @@ export class Column {
     public readonly ns: string;
 
     public readonly schema_name: string;
-    public readonly column_name: string;
+    public readonly name: string;
     public readonly column_type: string;
     
     public readonly audited: boolean;
@@ -23,7 +23,7 @@ export class Column {
         this.ns = flat.ns;
 
         this.schema_name = flat.schema_name;
-        this.column_name = flat.column_name;
+        this.name = flat.name;
         this.column_type = flat.column_type;
 
         this.audited = flat.audited;
@@ -40,6 +40,6 @@ export class Column {
     // Bonus
 
     get column_path(): string {
-        return this.schema_name + ':' + this.column_name;
+        return this.schema_name + ':' + this.name;
     }
 }

--- a/src/classes/kernel-meta.spec.ts
+++ b/src/classes/kernel-meta.spec.ts
@@ -121,7 +121,7 @@ test.skip('column => database table lifecycle', async () => {
     chai.expect(parent.meta).property('deleted_by').null;
 
     // Setup the column
-    let record_data = { schema_name: parent.data.schema_name, name: 'test_text', column_type: 'text' };
+    let record_data = { schema_name: parent.data.schema_name, name: 'test_text', type: 'text' };
 
     // Insert the new column record
     let record = await kernel.data.createOne(SchemaType.Column, record_data);
@@ -132,7 +132,7 @@ test.skip('column => database table lifecycle', async () => {
     chai.expect(record.data).property('ns', kernel.user_ns);
     chai.expect(record.data).property('schema_name', record_data.schema_name);
     chai.expect(record.data).property('name', record_data.name);
-    chai.expect(record.data).property('column_type', record_data.column_type);
+    chai.expect(record.data).property('type', record_data.type);
     chai.expect(record.meta).property('created_at');
     chai.expect(record.meta).property('created_by', kernel.user_id);
     chai.expect(record.meta).property('expired_at').null;

--- a/src/classes/kernel-meta.spec.ts
+++ b/src/classes/kernel-meta.spec.ts
@@ -25,7 +25,7 @@ afterEach(async () => {
 
 test.skip('schema => database table lifecycle', async () => {
     let schema_name = kernel.toTestSchemaName();
-    let record_data = { schema_name: schema_name, type: 'database' };
+    let record_data = { name: schema_name, type: 'database' };
     let record: Record;
 
     // Insert the new schema record
@@ -102,7 +102,7 @@ test.skip('schema => database table lifecycle', async () => {
 test.skip('column => database table lifecycle', async () => {
     // Setup the schema
     let schema_name = kernel.toTestSchemaName();
-    let parent_data = { schema_name: schema_name, type: 'database' };
+    let parent_data = { name: schema_name, type: 'database' };
 
     // Insert the new schema record
     let parent = await kernel.data.createOne(SchemaType.Schema, parent_data);
@@ -111,7 +111,7 @@ test.skip('column => database table lifecycle', async () => {
     chai.expect(parent).property('data').a('object');
     chai.expect(parent.data).property('id').string;
     chai.expect(parent.data).property('ns', kernel.user_ns);
-    chai.expect(parent.data).property('schema_name', parent_data.schema_name);
+    chai.expect(parent.data).property('name', parent_data.name);
     chai.expect(parent.data).property('type', parent_data.type);
     chai.expect(parent.meta).property('created_at');
     chai.expect(parent.meta).property('created_by', kernel.user_id);
@@ -121,7 +121,7 @@ test.skip('column => database table lifecycle', async () => {
     chai.expect(parent.meta).property('deleted_by').null;
 
     // Setup the column
-    let record_data = { schema_name: parent.data.schema_name, name: 'test_text', type: 'text' };
+    let record_data = { schema_name: parent.data.name, name: 'test_text', type: 'text' };
 
     // Insert the new column record
     let record = await kernel.data.createOne(SchemaType.Column, record_data);
@@ -141,11 +141,11 @@ test.skip('column => database table lifecycle', async () => {
     chai.expect(record.meta).property('deleted_by').null;
 
     // Column should be present in the meta service
-    chai.expect(kernel.meta.schemas).property(parent_data.schema_name).instanceOf(Schema);
-    chai.expect(kernel.meta.schemas[parent_data.schema_name].columns).property('test_text').instanceOf(Column);
+    chai.expect(kernel.meta.schemas).property(parent_data.name).instanceOf(Schema);
+    chai.expect(kernel.meta.schemas[parent_data.name].columns).property('test_text').instanceOf(Column);
 
     // We should have the test schema available
-    let tested_schema = kernel.meta.schemas[parent.data.schema_name];
+    let tested_schema = kernel.meta.schemas[parent.data.name];
     let tested = await kernel.data.createOne(tested_schema, { test_text: 'this is a column' });
 
     chai.expect(tested).instanceOf(Record);
@@ -207,8 +207,8 @@ test.skip('column => database table lifecycle', async () => {
     chai.expect(record.meta).property('deleted_by', kernel.user_id);
 
     // Column should not be present in the meta service
-    chai.expect(kernel.meta.schemas).property(parent_data.schema_name).instanceOf(Schema);
-    chai.expect(kernel.meta.schemas[parent_data.schema_name].columns).not.property('test_text');
+    chai.expect(kernel.meta.schemas).property(parent_data.name).instanceOf(Schema);
+    chai.expect(kernel.meta.schemas[parent_data.name].columns).not.property('test_text');
 
     // Column should be deleted, so we shouldn't see the data when selected
     let [retest] = await kernel.data.selectAny(tested_schema, { limit: 1 });

--- a/src/classes/kernel-meta.spec.ts
+++ b/src/classes/kernel-meta.spec.ts
@@ -25,7 +25,7 @@ afterEach(async () => {
 
 test.skip('schema => database table lifecycle', async () => {
     let schema_name = kernel.toTestSchemaName();
-    let record_data = { schema_name: schema_name, schema_type: 'database' };
+    let record_data = { schema_name: schema_name, type: 'database' };
     let record: Record;
 
     // Insert the new schema record
@@ -102,7 +102,7 @@ test.skip('schema => database table lifecycle', async () => {
 test.skip('column => database table lifecycle', async () => {
     // Setup the schema
     let schema_name = kernel.toTestSchemaName();
-    let parent_data = { schema_name: schema_name, schema_type: 'database' };
+    let parent_data = { schema_name: schema_name, type: 'database' };
 
     // Insert the new schema record
     let parent = await kernel.data.createOne(SchemaType.Schema, parent_data);
@@ -112,7 +112,7 @@ test.skip('column => database table lifecycle', async () => {
     chai.expect(parent.data).property('id').string;
     chai.expect(parent.data).property('ns', kernel.user_ns);
     chai.expect(parent.data).property('schema_name', parent_data.schema_name);
-    chai.expect(parent.data).property('schema_type', parent_data.schema_type);
+    chai.expect(parent.data).property('type', parent_data.type);
     chai.expect(parent.meta).property('created_at');
     chai.expect(parent.meta).property('created_by', kernel.user_id);
     chai.expect(parent.meta).property('expired_at').null;

--- a/src/classes/kernel-meta.spec.ts
+++ b/src/classes/kernel-meta.spec.ts
@@ -121,7 +121,7 @@ test.skip('column => database table lifecycle', async () => {
     chai.expect(parent.meta).property('deleted_by').null;
 
     // Setup the column
-    let record_data = { schema_name: parent.data.schema_name, column_name: 'test_text', column_type: 'text' };
+    let record_data = { schema_name: parent.data.schema_name, name: 'test_text', column_type: 'text' };
 
     // Insert the new column record
     let record = await kernel.data.createOne(SchemaType.Column, record_data);
@@ -131,7 +131,7 @@ test.skip('column => database table lifecycle', async () => {
     chai.expect(record.data).property('id').string;
     chai.expect(record.data).property('ns', kernel.user_ns);
     chai.expect(record.data).property('schema_name', record_data.schema_name);
-    chai.expect(record.data).property('column_name', record_data.column_name);
+    chai.expect(record.data).property('name', record_data.name);
     chai.expect(record.data).property('column_type', record_data.column_type);
     chai.expect(record.meta).property('created_at');
     chai.expect(record.meta).property('created_by', kernel.user_id);

--- a/src/classes/kernel-meta.ts
+++ b/src/classes/kernel-meta.ts
@@ -52,7 +52,7 @@ export class KernelMeta implements Service {
             let schema = new Schema(source);
 
             // Install
-            this.schemas.set(source.schema_name, schema);
+            this.schemas.set(source.name, schema);
         }
 
         // Instantiate
@@ -110,7 +110,7 @@ export class KernelMeta implements Service {
 
     find_schema(schema_name: string) {
         return _.find(this.sources.get(SchemaType.Schema), source => {
-            return source.schema_name === schema_name;
+            return source.name === schema_name;
         });
     }
 

--- a/src/classes/kernel-meta.ts
+++ b/src/classes/kernel-meta.ts
@@ -57,14 +57,14 @@ export class KernelMeta implements Service {
 
         // Instantiate
         for(let source of await this.load(SchemaType.Column)) {
-            let schema = this.schemas.get(source.schema_name);
             let column = new Column(source);
+            let schema = this.schemas.get(column.schema_name);
 
             // Install
-            this.columns.set(column.column_path, column);
+            this.columns.set(column.name, column);
 
             // Cross reference
-            schema.columns.set(source.name, column);
+            schema.columns.set(column.column_name, column);
         }
     }
     
@@ -105,19 +105,6 @@ export class KernelMeta implements Service {
     find_source(schema_path: string, match: string, k: string = 'name') {
         return _.find(this.sources.get(schema_path), source => {
             return source[k] === match;
-        });
-    }
-
-    find_schema(schema_name: string) {
-        return _.find(this.sources.get(SchemaType.Schema), source => {
-            return source.name === schema_name;
-        });
-    }
-
-    find_column(schema_name: string, name: string) {
-        return _.find(this.sources.get(SchemaType.Column), source => {
-            return source.schema_name === schema_name
-                && source.name === name;
         });
     }
 }

--- a/src/classes/kernel-meta.ts
+++ b/src/classes/kernel-meta.ts
@@ -64,7 +64,7 @@ export class KernelMeta implements Service {
             this.columns.set(column.column_path, column);
 
             // Cross reference
-            schema.columns.set(source.column_name, column);
+            schema.columns.set(source.name, column);
         }
     }
     
@@ -114,10 +114,10 @@ export class KernelMeta implements Service {
         });
     }
 
-    find_column(schema_name: string, column_name: string) {
+    find_column(schema_name: string, name: string) {
         return _.find(this.sources.get(SchemaType.Column), source => {
             return source.schema_name === schema_name
-                && source.column_name === column_name;
+                && source.name === name;
         });
     }
 }

--- a/src/classes/kernel.spec.ts
+++ b/src/classes/kernel.spec.ts
@@ -10,8 +10,13 @@ import { Tester } from '@classes/tester';
 
 let kernel = new Tester();
 
-beforeEach(() => kernel.startup());
-afterEach(() => kernel.cleanup());
+beforeEach(async () => {
+    await kernel.startup();
+});
+
+afterEach(async () => {
+    await kernel.cleanup();
+});
 
 test('tx test: insert a user => should rollback', async () => {
     let result = await kernel.data.createOne('system.user', { name: 'kernel-tx-test' });

--- a/src/classes/record.ts
+++ b/src/classes/record.ts
@@ -73,7 +73,7 @@ function createProxy(schema: Schema, source_type: 'data' | 'meta' | 'acls') {
             return;
         }
 
-        assert.fail(`schema '${schema.schema_name}' column '${name}' is invalid for 'record.${source_type}'`);
+        assert.fail(`schema '${schema.name}' column '${name}' is invalid for 'record.${source_type}'`);
     }
 
     // Build and return the new Proxy
@@ -146,7 +146,7 @@ export class Record {
     }
 
     toString(): string {
-        return `${this.schema.schema_name}#${this.data.id}`;
+        return `${this.schema.name}#${this.data.id}`;
     }
 
     toJSON() {

--- a/src/classes/record.ts
+++ b/src/classes/record.ts
@@ -56,24 +56,24 @@ function createProxy(schema: Schema, source_type: 'data' | 'meta' | 'acls') {
         source.acls_deny = null;
     }
 
-    let assertFn = (column_name: string) => {
-        if (source_type === 'data' && column_name === 'id') {
+    let assertFn = (name: string) => {
+        if (source_type === 'data' && name === 'id') {
             return;
         }
 
-        if (source_type === 'data' && column_name === 'ns') {
+        if (source_type === 'data' && name === 'ns') {
             return;
         }
 
-        if (source_type === 'data' && schema.columns.has(column_name)) {
+        if (source_type === 'data' && schema.columns.has(name)) {
             return;
         }
 
-        if (source_type === 'meta' && ColumnsMeta.includes(column_name)) {
+        if (source_type === 'meta' && ColumnsMeta.includes(name)) {
             return;
         }
 
-        assert.fail(`schema '${schema.schema_name}' column '${column_name}' is invalid for 'record.${source_type}'`);
+        assert.fail(`schema '${schema.schema_name}' column '${name}' is invalid for 'record.${source_type}'`);
     }
 
     // Build and return the new Proxy
@@ -82,17 +82,17 @@ function createProxy(schema: Schema, source_type: 'data' | 'meta' | 'acls') {
             return Reflect.ownKeys(target);
         },
 
-        get(target: _.Dictionary<any>, column_name: string) {
-            if (column_name === 'toJSON') return target;
-            if (column_name === 'constructor') return undefined;
-            if (column_name === 'length') return undefined;
-            assertFn(column_name);
-            return target[column_name] ?? null;
+        get(target: _.Dictionary<any>, name: string) {
+            if (name === 'toJSON') return target;
+            if (name === 'constructor') return undefined;
+            if (name === 'length') return undefined;
+            assertFn(name);
+            return target[name] ?? null;
         },
 
-        set(target: _.Dictionary<any>, column_name: string, data: any) {
-            assertFn(column_name);
-            target[column_name] = data;
+        set(target: _.Dictionary<any>, name: string, data: any) {
+            assertFn(name);
+            target[name] = data;
             return true;
         }
     });
@@ -161,19 +161,19 @@ export class Record {
     }
 
     has(column: Column): boolean {
-        return this.data[column.column_name]
-            || this.prev[column.column_name];
+        return this.data[column.name]
+            || this.prev[column.name];
     }
 
     get(column: Column) {
-        return this.data[column.column_name] ?? null;
+        return this.data[column.name] ?? null;
     }
 
     old(column: Column) {
-        return this.prev[column.column_name] ?? null;
+        return this.prev[column.name] ?? null;
     }
 
     set(column: Column, data: any) {
-        return this.data[column.column_name] = data;
+        return this.data[column.name] = data;
     }
 }

--- a/src/classes/record.ts
+++ b/src/classes/record.ts
@@ -161,19 +161,19 @@ export class Record {
     }
 
     has(column: Column): boolean {
-        return this.data[column.name]
-            || this.prev[column.name];
+        return this.data[column.column_name]
+            || this.prev[column.column_name];
     }
 
     get(column: Column) {
-        return this.data[column.name] ?? null;
+        return this.data[column.column_name] ?? null;
     }
 
     old(column: Column) {
-        return this.prev[column.name] ?? null;
+        return this.prev[column.column_name] ?? null;
     }
 
     set(column: Column, data: any) {
-        return this.data[column.name] = data;
+        return this.data[column.column_name] = data;
     }
 }

--- a/src/classes/schema.ts
+++ b/src/classes/schema.ts
@@ -21,7 +21,7 @@ export class Schema {
     public readonly id: string;
     public readonly ns: string;
 
-    public readonly schema_name: string;
+    public readonly name: string;
     public readonly type: string;
     public readonly metadata: boolean;
 
@@ -29,7 +29,7 @@ export class Schema {
         this.id = flat.id;
         this.ns = flat.ns;
 
-        this.schema_name = flat.schema_name;
+        this.name = flat.name;
         this.type = flat.type;
         this.metadata = flat.metadata;
     }
@@ -41,7 +41,7 @@ export class Schema {
     }
 
     is(schema_name: string) {
-        return this.schema_name === schema_name;
+        return this.name === schema_name;
     }
     
     toRecord(source?: any) {

--- a/src/classes/schema.ts
+++ b/src/classes/schema.ts
@@ -34,14 +34,25 @@ export class Schema {
         this.metadata = flat.metadata;
     }
 
+    /**
+     * Returns the two path parts of the schema name. For example, if the schema's full name is `system.domain`, then
+     * calling the `path()` function will return an array `['system', 'domain']`.
+     * @returns 
+     */
+    path() {
+        return this.name.split('.');
+    }
+
     column_keys(prefix?: string) {
         return Array.from(this.columns.keys()).map(k => {
             return prefix ? prefix + '.' + k : k;
         });
     }
 
-    is(schema_name: string) {
-        return this.name === schema_name;
+
+
+    is(name: string) {
+        return this.name === name;
     }
     
     toRecord(source?: any) {

--- a/src/classes/schema.ts
+++ b/src/classes/schema.ts
@@ -22,7 +22,7 @@ export class Schema {
     public readonly ns: string;
 
     public readonly schema_name: string;
-    public readonly schema_type: string;
+    public readonly type: string;
     public readonly metadata: boolean;
 
     constructor(flat: _.Dictionary<any>) {
@@ -30,7 +30,7 @@ export class Schema {
         this.ns = flat.ns;
 
         this.schema_name = flat.schema_name;
-        this.schema_type = flat.schema_type;
+        this.type = flat.type;
         this.metadata = flat.metadata;
     }
 

--- a/src/classes/tester.ts
+++ b/src/classes/tester.ts
@@ -36,10 +36,10 @@ export class Tester extends Kernel {
 
     async createTestTable()  {
         let record = await this.data.createOne(SchemaType.Schema, { 
-            schema_name: this.toTestSchemaName()
+            name: this.toTestSchemaName()
         });
 
-        return this.meta.schemas.get(record.data.schema_name);
+        return this.meta.schemas.get(record.data.name);
     }
 
     toTestSchemaName() {

--- a/src/classes/thread.ts
+++ b/src/classes/thread.ts
@@ -57,7 +57,7 @@ export class Thread {
             }
 
             // Wrong schema name?
-            if (observer.onSchema() != '*' && observer.onSchema() !== this.schema.schema_name) {
+            if (observer.onSchema() != '*' && observer.onSchema() !== this.schema.name) {
                 return false;
             }
 
@@ -105,7 +105,7 @@ export class Thread {
 
         for(let observer of observers) {
             // console.info(util.format('Thread: schema=%j op=%j ring=%j rank=%j observer=%j', 
-            //     this.schema.schema_name, 
+            //     this.schema.name, 
             //     this.op, 
             //     observer.onRing(),
             //     observer.onRank(),

--- a/src/observers/system.column/create-columns.spec.ts
+++ b/src/observers/system.column/create-columns.spec.ts
@@ -12,11 +12,6 @@ import { Tester } from '@classes/tester';
 import { SchemaType } from '@typedefs/schema';
 
 let kernel = new Tester();
-let source_data = { 
-    schema_name: SchemaType.User, 
-    name: 'something', 
-    type: 'text' 
-};
 
 beforeEach(async () => {
     await kernel.startup();
@@ -27,19 +22,22 @@ afterEach(async () => {
 });
 
 test('should create a knex column', async () => {
-    await kernel.data.createOne(SchemaType.Column, source_data);
+    await kernel.data.createOne(SchemaType.Column, { 
+        name: SchemaType.User + ':something', 
+        type: 'text' 
+    });
 
-    // // Make sure we can insert records
-    // await kernel.data.createOne(SchemaType.User, {
-    //     name: 'username',
-    //     something: 'this is some type of value'
-    // });
+    // Make sure we can insert records
+    await kernel.data.createOne(SchemaType.User, {
+        name: 'username',
+        something: 'this is some type of value'
+    });
 
-    // // Check using direct knex
-    // let select = await kernel.knex.driverTo(SchemaType.User).select().first();
+    // Check using direct knex
+    let select = await kernel.knex.driverTo(SchemaType.User).select().first();
 
-    // chai.expect(select).a('object');
-    // chai.expect(select).property('id').string;
-    // chai.expect(select).property('something');
+    chai.expect(select).a('object');
+    chai.expect(select).property('id').string;
+    chai.expect(select).property('something');
 });
 

--- a/src/observers/system.column/create-columns.spec.ts
+++ b/src/observers/system.column/create-columns.spec.ts
@@ -15,7 +15,7 @@ let kernel = new Tester();
 let source_data = { 
     schema_name: SchemaType.User, 
     name: 'something', 
-    column_type: 'text' 
+    type: 'text' 
 };
 
 beforeEach(async () => {

--- a/src/observers/system.column/create-columns.spec.ts
+++ b/src/observers/system.column/create-columns.spec.ts
@@ -14,7 +14,7 @@ import { SchemaType } from '@typedefs/schema';
 let kernel = new Tester();
 let source_data = { 
     schema_name: SchemaType.User, 
-    column_name: 'something', 
+    name: 'something', 
     column_type: 'text' 
 };
 

--- a/src/observers/system.column/create-columns.ts
+++ b/src/observers/system.column/create-columns.ts
@@ -36,7 +36,7 @@ export default class extends Observer {
     async one(thread: Thread, record: Record) {
         let schema_name = record.data.schema_name;
         let column_name = record.data.name;
-        let column_type = record.data.column_type;
+        let column_type = record.data.type;
 
         let [ ns, sn ] = record.data.schema_name.split('.');
 

--- a/src/observers/system.column/create-columns.ts
+++ b/src/observers/system.column/create-columns.ts
@@ -34,13 +34,16 @@ export default class extends Observer {
     }
 
     async one(thread: Thread, record: Record) {
-        let schema_name = record.data.schema_name;
-        let column_name = record.data.name;
-        let column_type = record.data.type;
+        // Create temporary refs
+        let column = new Column(record.data);
+        let schema = thread.kernel.meta.schemas.get(column.schema_name);
 
-        let [ ns, sn ] = record.data.schema_name.split('.');
+        let [ ns, sn ] = schema.name.split('.');
 
         await thread.kernel.knex.schema.table(`${ns}__data.${sn}`, t => {            
+            let column_type = column.type;
+            let column_name = column.column_name;
+
             if (column_type === ColumnType.Text) {
                 return t.text(column_name);
             }
@@ -68,14 +71,10 @@ export default class extends Observer {
             // Invalid column type
         });
 
-        // Setup
-        let schema = thread.kernel.meta.schemas.get(schema_name);
-        let column = new Column(record.data);
-
         // Add the column data to the parent schema
-        schema.columns.set(column_name, column);
+        schema.columns.set(column.column_name, column);
 
         // Add the column data to the kernel metadata
-        thread.kernel.meta.columns.set(column.column_path, column);
+        thread.kernel.meta.columns.set(column.name, column);
     }
 }

--- a/src/observers/system.column/create-columns.ts
+++ b/src/observers/system.column/create-columns.ts
@@ -34,7 +34,10 @@ export default class extends Observer {
     }
 
     async one(thread: Thread, record: Record) {
-        let { schema_name, column_name, column_type } = record.data;
+        let schema_name = record.data.schema_name;
+        let column_name = record.data.name;
+        let column_type = record.data.column_type;
+
         let [ ns, sn ] = record.data.schema_name.split('.');
 
         await thread.kernel.knex.schema.table(`${ns}__data.${sn}`, t => {            

--- a/src/observers/system.column/delete-columns.spec.ts
+++ b/src/observers/system.column/delete-columns.spec.ts
@@ -16,7 +16,7 @@ let kernel = new Tester();
 let source_data = { 
     schema_name: SchemaType.User, 
     name: 'something', 
-    column_type: 'text' 
+    type: 'text' 
 };
 
 beforeEach(async () => {

--- a/src/observers/system.column/delete-columns.spec.ts
+++ b/src/observers/system.column/delete-columns.spec.ts
@@ -15,7 +15,7 @@ import { SchemaType } from '@typedefs/schema';
 let kernel = new Tester();
 let source_data = { 
     schema_name: SchemaType.User, 
-    column_name: 'something', 
+    name: 'something', 
     column_type: 'text' 
 };
 

--- a/src/observers/system.column/delete-columns.spec.ts
+++ b/src/observers/system.column/delete-columns.spec.ts
@@ -13,11 +13,6 @@ import { Schema } from '@classes/schema';
 import { SchemaType } from '@typedefs/schema';
 
 let kernel = new Tester();
-let source_data = { 
-    schema_name: SchemaType.User, 
-    name: 'something', 
-    type: 'text' 
-};
 
 beforeEach(async () => {
     await kernel.startup();
@@ -27,8 +22,11 @@ afterEach(async () => {
     await kernel.cleanup();
 });
 
-test('should create a knex column', async () => {
-    let record = await kernel.data.createOne(SchemaType.Column, source_data);
+test('should delete a knex column', async () => {
+    let record = await kernel.data.createOne(SchemaType.Column, { 
+        name: SchemaType.User + ':something', 
+        type: 'text' 
+    });
 
     // Make sure we can insert records
     await kernel.data.createOne(SchemaType.User, {

--- a/src/observers/system.column/delete-columns.ts
+++ b/src/observers/system.column/delete-columns.ts
@@ -32,7 +32,10 @@ export default class extends Observer {
     }
 
     async one(thread: Thread, record: Record) {
-        let { schema_name, column_name, column_type } = record.data;
+        let schema_name = record.data.schema_name;
+        let column_name = record.data.name;
+        let column_type = record.data.column_type;
+
         let [ ns, sn ] = record.data.schema_name.split('.');
 
         await thread.kernel.knex.schema.table(`${ns}__data.${sn}`, t => {            

--- a/src/observers/system.column/delete-columns.ts
+++ b/src/observers/system.column/delete-columns.ts
@@ -34,7 +34,7 @@ export default class extends Observer {
     async one(thread: Thread, record: Record) {
         let schema_name = record.data.schema_name;
         let column_name = record.data.name;
-        let column_type = record.data.column_type;
+        let column_type = record.data.type;
 
         let [ ns, sn ] = record.data.schema_name.split('.');
 

--- a/src/observers/system.record/knex-create.ts
+++ b/src/observers/system.record/knex-create.ts
@@ -40,7 +40,7 @@ export default class extends Observer {
 
     async run(thread: Thread): Promise<void> {
         let creates = await thread.kernel.knex
-            .driverTo(thread.schema.schema_name, 'data')
+            .driverTo(thread.schema.name, 'data')
             .insert(thread.change_data)
             .returning('*');
 

--- a/src/observers/system.record/knex-delete.ts
+++ b/src/observers/system.record/knex-delete.ts
@@ -27,7 +27,7 @@ export default class extends Observer {
 
     async run(thread: Thread): Promise<void> {
         return thread.kernel.knex
-            .driverTo(thread.schema.schema_name, 'meta')
+            .driverTo(thread.schema.name, 'meta')
             .whereIn('id', _.map(thread.change_data, 'id'))
             .update({
                 deleted_at: thread.kernel.time,

--- a/src/observers/system.record/knex-expire.ts
+++ b/src/observers/system.record/knex-expire.ts
@@ -27,7 +27,7 @@ export default class extends Observer {
 
     async run(thread: Thread): Promise<void> {
         return thread.kernel.knex
-            .driverTo(thread.schema.schema_name, 'meta')
+            .driverTo(thread.schema.name, 'meta')
             .whereIn('id', _.map(thread.change_data, 'id'))
             .update({
                 expired_at: thread.kernel.time,

--- a/src/observers/system.record/knex-select.spec.ts
+++ b/src/observers/system.record/knex-select.spec.ts
@@ -53,12 +53,12 @@ test('"where" with 1 column', async () => {
 });
 
 test('"where" with 3 columns', async () => {
-    let result = await selectWhere({ schema_name: 'system.column', column_name: 'required', column_type: 'boolean' });
+    let result = await selectWhere({ schema_name: 'system.column', name: 'required', column_type: 'boolean' });
     chai.expect(result).an('array').not.empty;
 });
 
 test('"where" with 3 columns where 1 is incorrect', async () => {
-    let result = await selectWhere({ schema_name: 'system.column', column_name: 'required', column_type: 'text' });
+    let result = await selectWhere({ schema_name: 'system.column', name: 'required', column_type: 'text' });
     chai.expect(result).an('array').empty;
 });
 
@@ -155,12 +155,12 @@ test('"order" is empty', async () => {
 });
 
 test('"order" has 1 column with sort $asc', async () => {
-    let result = await selectOrder({ column_name: 'asc' });
+    let result = await selectOrder({ name: 'asc' });
     chai.expect(result).an('array').not.empty;
 });
 
 test('"order" has multiple columns with mixed sort', async () => {
-    let result = await selectOrder({ column_name: 'asc', column_type: 'desc'});
+    let result = await selectOrder({ name: 'asc', column_type: 'desc'});
     chai.expect(result).an('array').not.empty;
 });
 

--- a/src/observers/system.record/knex-select.spec.ts
+++ b/src/observers/system.record/knex-select.spec.ts
@@ -48,88 +48,88 @@ test('"where" empty search', async () => {
 });
 
 test('"where" with 1 column', async () => {
-    let result = await selectWhere({ schema_name: 'system.column' });
+    let result = await selectWhere({ name: 'system.column:required' });
     chai.expect(result).an('array').not.empty;
 });
 
 test('"where" with 3 columns', async () => {
-    let result = await selectWhere({ schema_name: 'system.column', name: 'required', type: 'boolean' });
+    let result = await selectWhere({ name: 'system.column:required', type: 'boolean' });
     chai.expect(result).an('array').not.empty;
 });
 
 test('"where" with 3 columns where 1 is incorrect', async () => {
-    let result = await selectWhere({ schema_name: 'system.column', name: 'required', type: 'text' });
+    let result = await selectWhere({ name: 'system.column:required', type: 'text' });
     chai.expect(result).an('array').empty;
 });
 
 test('"where" with 1 column using null', async () => {
-    let result = await selectWhere({ schema_name: null});
+    let result = await selectWhere({ name: null});
     chai.expect(result).an('array').empty;
 });
 
 test('"where" with 1 column using $not and null', async () => {
-    let result = await selectWhere({ schema_name: { $not: null }});
+    let result = await selectWhere({ name: { $not: null }});
     chai.expect(result).an('array').not.empty;
 });
 
 test('"where" with 1 column using $eq and null', async () => {
-    let result = await selectWhere({ schema_name: { $eq: null }});
+    let result = await selectWhere({ name: { $eq: null }});
     chai.expect(result).an('array').empty;
 });
 
 test('"where" with 1 column using $eq', async () => {
-    let result = await selectWhere({ schema_name: { $eq: 'system.column' }});
+    let result = await selectWhere({ name: { $eq: 'system.column:required' }});
     chai.expect(result).an('array').not.empty;
 });
 
 test('"where" with 1 column using $ne and null', async () => {
-    let result = await selectWhere({ schema_name: { $ne: null }});
+    let result = await selectWhere({ name: { $ne: null }});
     chai.expect(result).an('array').not.empty;
 });
 
 test('"where" with 1 column using $ne', async () => {
-    let result = await selectWhere({ schema_name: { $ne: 'system.column' }});
+    let result = await selectWhere({ name: { $ne: 'system.column:required' }});
     chai.expect(result).an('array').not.empty;
 });
 
 test('"where" with 1 column using $gt', async () => {
-    let result = await selectWhere({ schema_name: { $gt: 'system.column' }});
+    let result = await selectWhere({ name: { $gt: 'system.column' }});
     chai.expect(result).an('array').not.empty;
 });
 
 test('"where" with 1 column using $gte', async () => {
-    let result = await selectWhere({ schema_name: { $gte: 'system.column' }});
+    let result = await selectWhere({ name: { $gte: 'system.column' }});
     chai.expect(result).an('array').not.empty;
 });
 
 test('"where" with 1 column using $lt', async () => {
-    let result = await selectWhere({ schema_name: { $lt: 'system.schema' }});
+    let result = await selectWhere({ name: { $lt: 'system.schema' }});
     chai.expect(result).an('array').not.empty;
 });
 
 test('"where" with 1 column using $lte', async () => {
-    let result = await selectWhere({ schema_name: { $lte: 'system.schema' }});
+    let result = await selectWhere({ name: { $lte: 'system.schema' }});
     chai.expect(result).an('array').not.empty;
 });
 
 test('"where" with 1 column using $in', async () => {
-    let result = await selectWhere({ schema_name: { $in: ['system.schema'] }});
+    let result = await selectWhere({ name: { $in: ['system.column:required'] }});
     chai.expect(result).an('array').not.empty;
 });
 
 test('"where" with 1 column using $nin', async () => {
-    let result = await selectWhere({ schema_name: { $in: ['system.schema'] }});
+    let result = await selectWhere({ name: { $nin: ['system.column:required'] }});
     chai.expect(result).an('array').not.empty;
 });
 
 test('"where" with 1 column using $find', async () => {
-    let result = await selectWhere({ schema_name: { $find: '%schema%' }});
+    let result = await selectWhere({ name: { $find: '%schema%' }});
     chai.expect(result).an('array').not.empty;
 });
 
 test('"where" with $and', async () => {
     let result = await selectWhere({ $and: [
-        { schema_name: 'system.column' },
+        { name: 'system.column:required' },
         { type: 'text' }
     ]});
 
@@ -138,8 +138,8 @@ test('"where" with $and', async () => {
 
 test('"where" with $or', async () => {
     let result = await selectWhere({ $or: [
-        { schema_name: 'system.column' },
-        { schema_name: 'system.schema' }
+        { name: 'system.column:required' },
+        { name: 'system.schema:indexed' }
     ]});
 
     chai.expect(result).an('array').not.empty;

--- a/src/observers/system.record/knex-select.spec.ts
+++ b/src/observers/system.record/knex-select.spec.ts
@@ -53,12 +53,12 @@ test('"where" with 1 column', async () => {
 });
 
 test('"where" with 3 columns', async () => {
-    let result = await selectWhere({ schema_name: 'system.column', name: 'required', column_type: 'boolean' });
+    let result = await selectWhere({ schema_name: 'system.column', name: 'required', type: 'boolean' });
     chai.expect(result).an('array').not.empty;
 });
 
 test('"where" with 3 columns where 1 is incorrect', async () => {
-    let result = await selectWhere({ schema_name: 'system.column', name: 'required', column_type: 'text' });
+    let result = await selectWhere({ schema_name: 'system.column', name: 'required', type: 'text' });
     chai.expect(result).an('array').empty;
 });
 
@@ -130,7 +130,7 @@ test('"where" with 1 column using $find', async () => {
 test('"where" with $and', async () => {
     let result = await selectWhere({ $and: [
         { schema_name: 'system.column' },
-        { column_type: 'text' }
+        { type: 'text' }
     ]});
 
     chai.expect(result).an('array').not.empty;
@@ -160,7 +160,7 @@ test('"order" has 1 column with sort $asc', async () => {
 });
 
 test('"order" has multiple columns with mixed sort', async () => {
-    let result = await selectOrder({ name: 'asc', column_type: 'desc'});
+    let result = await selectOrder({ name: 'asc', type: 'desc'});
     chai.expect(result).an('array').not.empty;
 });
 

--- a/src/observers/system.record/knex-select.ts
+++ b/src/observers/system.record/knex-select.ts
@@ -31,7 +31,7 @@ export default class extends Observer {
 
     async run(thread: Thread): Promise<void> {
         let schema = thread.schema;
-        let knex = thread.kernel.knex.selectTo(schema.schema_name);
+        let knex = thread.kernel.knex.selectTo(schema.name);
 
         // Filter out expired and deleted records
         knex = knex.whereNull('meta.expired_at');

--- a/src/observers/system.record/knex-update.ts
+++ b/src/observers/system.record/knex-update.ts
@@ -42,7 +42,7 @@ export default class extends Observer {
 
     async one(thread: Thread, record: Record) {
         return thread.kernel.knex
-            .driverTo(thread.schema.schema_name, 'data')
+            .driverTo(thread.schema.name, 'data')
             .whereIn('data.id', [record.data.id])
             .update(record.diff);
     }

--- a/src/observers/system.record/test-create.ts
+++ b/src/observers/system.record/test-create.ts
@@ -51,8 +51,8 @@ export default class extends Observer {
             // Per record, per Column
             //
 
-            for(let column_name of thread.schema.column_keys()) {
-                let column = thread.schema.columns.get(column_name);
+            for(let name of thread.schema.column_keys()) {
+                let column = thread.schema.columns.get(name);
                 
                 // Columns marked as `required=true` must have a value set
                 this.test_data_required(thread, record, column);
@@ -109,7 +109,7 @@ export default class extends Observer {
             return;
         }
 
-        thread.failures.push(`E_DATA_REQUIRED: A record of type '${ column.schema_name}' requires a value in '${ column.column_name }`);
+        thread.failures.push(`E_DATA_REQUIRED: A record of type '${ column.schema_name}' requires a value in '${ column.name }`);
     }
 
     test_data_minimum(thread: Thread, record: Record, column: Column) {
@@ -127,7 +127,7 @@ export default class extends Observer {
             return;
         }
 
-        thread.failures.push(`On create: a record of type '${ column.schema_name}' with a value in '${ column.column_name }' must have a value greater-or-equal to '${ column.minimum }`);
+        thread.failures.push(`On create: a record of type '${ column.schema_name}' with a value in '${ column.name }' must have a value greater-or-equal to '${ column.minimum }`);
     }
 
     test_data_maximum(thread: Thread, record: Record, column: Column) {
@@ -145,6 +145,6 @@ export default class extends Observer {
             return;
         }
 
-        thread.failures.push(`On create: a record of type '${ column.schema_name}' with a value in '${ column.column_name }' must have a value less-or-equal to '${ column.maximum }`);
+        thread.failures.push(`On create: a record of type '${ column.schema_name}' with a value in '${ column.name }' must have a value less-or-equal to '${ column.maximum }`);
     }
 }

--- a/src/observers/system.record/test-create.ts
+++ b/src/observers/system.record/test-create.ts
@@ -109,7 +109,7 @@ export default class extends Observer {
             return;
         }
 
-        thread.failures.push(`E_DATA_REQUIRED: A record of type '${ column.schema_name}' requires a value in '${ column.name }`);
+        thread.failures.push(`E_DATA_REQUIRED: A record of type '${ column.schema_name}' requires a value in '${ column.column_name }`);
     }
 
     test_data_minimum(thread: Thread, record: Record, column: Column) {
@@ -127,7 +127,7 @@ export default class extends Observer {
             return;
         }
 
-        thread.failures.push(`On create: a record of type '${ column.schema_name}' with a value in '${ column.name }' must have a value greater-or-equal to '${ column.minimum }`);
+        thread.failures.push(`On create: a record of type '${ column.schema_name}' with a value in '${ column.column_name }' must have a value greater-or-equal to '${ column.minimum }`);
     }
 
     test_data_maximum(thread: Thread, record: Record, column: Column) {
@@ -145,6 +145,6 @@ export default class extends Observer {
             return;
         }
 
-        thread.failures.push(`On create: a record of type '${ column.schema_name}' with a value in '${ column.name }' must have a value less-or-equal to '${ column.maximum }`);
+        thread.failures.push(`On create: a record of type '${ column.schema_name}' with a value in '${ column.column_name }' must have a value less-or-equal to '${ column.maximum }`);
     }
 }

--- a/src/observers/system.schema/create-tables.spec.ts
+++ b/src/observers/system.schema/create-tables.spec.ts
@@ -11,8 +11,6 @@ import { SchemaType } from '@typedefs/schema';
 
 
 let kernel = new Tester();
-let source_name = 'test.test_' + process.hrtime().join('_');
-let source_data = { schema_name: source_name };
 
 beforeEach(async () => {
     await kernel.startup();
@@ -25,7 +23,7 @@ afterEach(async () => {
 test.skip('should create a knex table', async () => {
     let schema_name = kernel.toTestSchemaName();    
     let schema_data = await kernel.data.createOne(SchemaType.Schema, {
-        schema_name: schema_name
+        name: schema_name
     });
 
     // Make sure the schema was inserted

--- a/src/observers/system.schema/create-tables.ts
+++ b/src/observers/system.schema/create-tables.ts
@@ -37,7 +37,7 @@ export default class extends Observer {
 
     async one(thread: Thread, record: Record) {
         // Setup
-        let schema_name = record.data.schema_name;
+        let schema_name = record.data.name;
         let schema_type = record.data.type;
         let auto = new AutoInstall(thread.kernel);
 

--- a/src/observers/system.schema/create-tables.ts
+++ b/src/observers/system.schema/create-tables.ts
@@ -37,7 +37,8 @@ export default class extends Observer {
 
     async one(thread: Thread, record: Record) {
         // Setup
-        let { schema_name, schema_type } = record.data;
+        let schema_name = record.data.schema_name;
+        let schema_type = record.data.type;
         let auto = new AutoInstall(thread.kernel);
 
         // Only create schemas that are marked as `database` types

--- a/src/observers/system.schema/delete-tables.spec.ts
+++ b/src/observers/system.schema/delete-tables.spec.ts
@@ -23,7 +23,7 @@ afterEach(async () => {
 test.skip('should delete a knex table', async () => {
     let schema_name = kernel.toTestSchemaName();
     let schema_data = await kernel.data.createOne(SchemaType.Schema, {
-        schema_name: schema_name
+        name: schema_name
     });
 
     // Make sure the schema was inserted

--- a/src/observers/system.schema/delete-tables.ts
+++ b/src/observers/system.schema/delete-tables.ts
@@ -32,7 +32,8 @@ export default class extends Observer {
     }
 
     async one(thread: Thread, record: Record) {
-        let { schema_name, schema_type } = record.data;
+        let schema_name = record.data.schema_name;
+        let schema_type = record.data.type;
         let auto = new AutoInstall(thread.kernel);
 
         // Only delete schemas that are marked as `database` types

--- a/src/observers/system.schema/delete-tables.ts
+++ b/src/observers/system.schema/delete-tables.ts
@@ -32,7 +32,7 @@ export default class extends Observer {
     }
 
     async one(thread: Thread, record: Record) {
-        let schema_name = record.data.schema_name;
+        let schema_name = record.data.name;
         let schema_type = record.data.type;
         let auto = new AutoInstall(thread.kernel);
 

--- a/src/observers/system.schema/test-schema-name.ts
+++ b/src/observers/system.schema/test-schema-name.ts
@@ -36,9 +36,9 @@ export default class extends Observer {
 
     async run(thread: Thread): Promise<void> {
         for(let record of thread.change) {
-            thread.expect(record.data).property('schema_name').includes('.');
+            thread.expect(record.data).property('name').includes('.');
 
-            let schema_name = record.data.schema_name;
+            let schema_name = record.data.name;
             let [ns, sn] = schema_name.split('.');
 
             thread.expect(ns, `schema_name '${schema_name}' (left side '${ns}')`).match(/^[a-z_0-9]+$/i);

--- a/src/routers/data-select-404.ts
+++ b/src/routers/data-select-404.ts
@@ -8,31 +8,17 @@ import { SchemaType } from '@typedefs/schema';
 // Implementation
 export default class extends Router {
     async run() {
-        let schema = this.kernel.meta.schemas.get(this.params.schema);
-
-        // If the record slug is a UUID, then search by ID.
         if (this.params.record.match(UUID_REGEX)) {
-            return this.kernel.data.select404(schema, this.params.record);
+            return this.kernel.data.select404(this.params.schema, this.params.record);
         }
 
-        // Is this a `system.schema`?
-        if (schema.is(SchemaType.Schema)) {
-            return this.kernel.data.search404(schema, { where: { schema_name: this.params.record }});
+        else if (this.params.record.includes('%')) {
+            return this.kernel.data.search404(this.params.schema, { where: { name: { $find: this.params.record }}});
         }
 
-        // Is this a `system.column`?
-        if (schema.is(SchemaType.Column)) {
-            let parts = this.params.record.split(':');
-            return this.kernel.data.search404(schema, { where: { schema_name: parts[0], name: parts[1] }});
+        else {
+            return this.kernel.data.search404(this.params.schema, { where: { name: this.params.record }});
         }
-
-        // Otherwise, if the schema has a `name` property, then search by the name
-        if (schema.columns.get('name')) {
-            return this.kernel.data.search404(schema, { where: { name: this.params.record }});
-        }
-
-        // Unknown how to handle this
-        this.kernel.expect(false, 'Unknown [record] slug type');
     }
 
     onHttpVerb() {

--- a/src/routers/data-select-404.ts
+++ b/src/routers/data-select-404.ts
@@ -23,7 +23,7 @@ export default class extends Router {
         // Is this a `system.column`?
         if (schema.is(SchemaType.Column)) {
             let parts = this.params.record.split(':');
-            return this.kernel.data.search404(schema, { where: { schema_name: parts[0], column_name: parts[1] }});
+            return this.kernel.data.search404(schema, { where: { schema_name: parts[0], name: parts[1] }});
         }
 
         // Otherwise, if the schema has a `name` property, then search by the name

--- a/src/routers/meta-select-one.ts
+++ b/src/routers/meta-select-one.ts
@@ -7,16 +7,7 @@ import { SchemaType } from '@typedefs/schema';
 // Implementation
 export default class extends Router {
     async run() {
-        let schema_name = this.params.schema;
-        let record_name = this.params.record;
-
-        if (schema_name === SchemaType.Schema) {
-            return this.kernel.data.search404(SchemaType.Schema, { where: { schema_name: record_name }});
-        }
-
-        else {
-            return this.kernel.data.search404(this.params.schema, { where: { name: record_name }});
-        }
+        return this.kernel.data.search404(this.params.schema, { where: { name: this.params.record_name }});
     }
 
     onHttpVerb() {


### PR DESCRIPTION
- Renamed `Column.column_name` to simple `name`
- Renamed `Column.column_type` to simple `type`
- Renamed `Schema.schema_type` to simple `type`
- Renamed `Schema.schema_name` to simple `name`
- Removed `schema_name` from `Column`
